### PR TITLE
Tests for Pages

### DIFF
--- a/test/pages_test/chat_list_screen_test.dart
+++ b/test/pages_test/chat_list_screen_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_nearby_connections_example/pages/ChatListScreen.dart';
+import 'package:flutter_nearby_connections_example/pages/ChatPage.dart';
+import 'package:flutter_nearby_connections_example/classes/Global.dart';
+
+void main() {
+  testWidgets('ChatListScreen UI Test', (WidgetTester tester) async {
+
+    Global.conversations['John Doe'] = {}; // Just a dummy conversation
+    Global.messages = []; // Clearing messages for a clean slate
+
+    await tester.pumpWidget(MaterialApp(home: ChatListScreen()));
+
+    await tester.pumpAndSettle();
+
+    // Verify that the UI is as expected
+    expect(find.text('Chats'), findsOneWidget);
+    expect(find.byType(BottomNavigationBar), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
+  });
+
+  testWidgets('ChatListScreen Interaction Test', (WidgetTester tester) async {
+
+    Global.conversations['John Doe'] = {}; // Just a dummy conversation
+    Global.messages = []; // Clearing messages for a clean slate
+
+    await tester.pumpWidget(MaterialApp(home: ChatListScreen()));
+
+    await tester.pumpAndSettle();
+
+    // Simulate tapping on a conversation
+    await tester.tap(find.text('John Doe'));
+
+    // Navigation to ChatPage
+    await tester.pumpAndSettle();
+
+    // Verify that we are on the ChatPage
+    expect(find.text('Chat with John Doe'), findsOneWidget);
+  });
+}

--- a/test/pages_test/chatpage_test.dart
+++ b/test/pages_test/chatpage_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_nearby_connections_example/pages/ChatPage.dart';
+import 'package:flutter_nearby_connections_example/classes/Global.dart';
+
+void main() {
+  testWidgets('ChatPage UI Test', (WidgetTester tester) async {
+    final String converser = 'John Doe';
+    await tester.pumpWidget(MaterialApp(home: ChatPage(converser)));
+    await tester.pumpAndSettle();
+
+    // Verify that the UI is as expected
+    expect(find.text('Chat with $converser'), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
+    expect(find.byType(TextFormField), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
+  });
+
+  testWidgets('ChatPage Interaction Test', (WidgetTester tester) async {
+    final String converser = 'John Doe';
+    await tester.pumpWidget(MaterialApp(home: ChatPage(converser)));
+    await tester.pumpAndSettle();
+
+    // Enter Text
+    await tester.enterText(find.byType(TextFormField), 'Hello, John!');
+
+    // Tap the send button
+    await tester.tap(find.byType(ElevatedButton));
+
+    // Wait for animations to complete
+    await tester.pumpAndSettle();
+
+    // Verify that the message is sent
+    expect(find.text('sent: Hello, John!'), findsOneWidget);
+  });
+}

--- a/test/pages_test/devicelistscreen_test.dart
+++ b/test/pages_test/devicelistscreen_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_nearby_connections_example/pages/DevicesListScreen.dart';
+import 'package:flutter_nearby_connections_example/pages/ChatPage.dart';
+import 'package:flutter_nearby_connections_example/classes/Global.dart';
+
+void main() {
+  testWidgets('DevicesListScreen UI Test', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: DevicesListScreen(deviceType: DeviceType.browser)));
+    await tester.pumpAndSettle();
+
+    // Verify that the UI is as expected
+    expect(find.text('Available Devices'), findsOneWidget);
+    expect(find.byType(TextFormField), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
+  });
+
+  testWidgets('DevicesListScreen Interaction Test', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: DevicesListScreen(deviceType: DeviceType.browser)));
+    await tester.pumpAndSettle();
+
+    // Simulate tapping on the first device in the list
+    await tester.tap(find.byType(GestureDetector).first);
+
+    // Wait for animations to complete
+    await tester.pumpAndSettle();
+
+    // Verify that we have navigated to ChatPage
+    expect(find.byType(ChatPage), findsOneWidget);
+  });
+}

--- a/test/pages_test/profile_test.dart
+++ b/test/pages_test/profile_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_nearby_connections_example/pages/Profile.dart';
+import 'package:flutter_nearby_connections_example/pages/DeviceListScreen.dart';
+import 'package:nanoid/nanoid.dart';
+import '../classes/Global.dart';
+
+void main() {
+  testWidgets('Profile UI Test', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: Profile()));
+
+    // Verify that the app has the expected text.
+    expect(find.text("Your Username will be your name+\$custom_length_id"), findsOneWidget);
+    expect(find.byType(TextFormField), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
+  });
+
+  testWidgets('Profile Interaction Test', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: Profile()));
+
+    // Enter a name into the TextFormField.
+    await tester.enterText(find.byType(TextFormField), 'JohnDoe');
+
+    // Tap on the save button.
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    // Verify that the Global.myName is updated.
+    expect(Global.myName, 'JohnDoe');
+
+    // Verify that the navigation to DeviceListScreen occurs.
+    expect(find.byType(DevicesListScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
PR for issue #11
Implemented unit tests to test the following pages within the app: Profile, DeviceListScreen, ChatPage, ChatListScreen.
Focused on testing the UI Functionality and Interaction between the pages.

Profile:
This is a UI test where a TextEditingController for the user's name is set, and then the app navigates to the DeviceListScreen when the "Save" button is pressed.

DeviceListScreen:
Ensuring that the UI functions and tapping simulations work as expected.

ChatPage:
The provided tests involve sending a message and checking if the UI updates accordingly.

ChatListScreen:
A UI test where the app navigates to the ChatPage when a user taps on a conversation.