### PR TITLE
Created an initialize method for Global Class

### DIFF
--- a/lib/classes/Global.dart
+++ b/lib/classes/Global.dart
@@ -21,4 +21,19 @@ class Global {
       Map(); //converser  mapped to conversation
   static String myName = '';
   static Map<String, dynamic> cache = Map();
+  static void initialize() {
+    devices = [];
+    connectedDevices = [];
+    nearbyService = null;
+    subscription = null;
+    receivedDataSubscription = null;
+    messages = [
+      Msg("1", "test", "sent", '2'),
+      Msg("2", "test2", "sent", '4')
+    ];
+    publicKeys = Map();
+    conversations = Map();
+    myName = '';
+    cache = Map();
+  }
 }

--- a/test/pages_test/chat_list_screen_test.dart
+++ b/test/pages_test/chat_list_screen_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_nearby_connections_example/pages/ChatListScreen.dart';
+import 'package:flutter_nearby_connections_example/pages/ChatPage.dart';
+import 'package:flutter_nearby_connections_example/classes/Global.dart';
+
+void main() {
+  testWidgets('ChatListScreen UI Test', (WidgetTester tester) async {
+
+    Global.conversations['John Doe'] = {}; // Just a dummy conversation
+    Global.messages = []; // Clearing messages for a clean slate
+
+    await tester.pumpWidget(MaterialApp(home: ChatListScreen()));
+
+    await tester.pumpAndSettle();
+
+    // Verify that the UI is as expected
+    expect(find.text('Chats'), findsOneWidget);
+    expect(find.byType(BottomNavigationBar), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
+  });
+
+  testWidgets('ChatListScreen Interaction Test', (WidgetTester tester) async {
+
+    Global.conversations['John Doe'] = {}; // Just a dummy conversation
+    Global.messages = []; // Clearing messages for a clean slate
+
+    await tester.pumpWidget(MaterialApp(home: ChatListScreen()));
+
+    await tester.pumpAndSettle();
+
+    // Simulate tapping on a conversation
+    await tester.tap(find.text('John Doe'));
+
+    // Navigation to ChatPage
+    await tester.pumpAndSettle();
+
+    // Verify that we are on the ChatPage
+    expect(find.text('Chat with John Doe'), findsOneWidget);
+  });
+}

--- a/test/pages_test/chatpage_test.dart
+++ b/test/pages_test/chatpage_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_nearby_connections_example/pages/ChatPage.dart';
+import 'package:flutter_nearby_connections_example/classes/Global.dart';
+
+void main() {
+  testWidgets('ChatPage UI Test', (WidgetTester tester) async {
+    final String converser = 'John Doe';
+    await tester.pumpWidget(MaterialApp(home: ChatPage(converser)));
+    await tester.pumpAndSettle();
+
+    // Verify that the UI is as expected
+    expect(find.text('Chat with $converser'), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
+    expect(find.byType(TextFormField), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
+  });
+
+  testWidgets('ChatPage Interaction Test', (WidgetTester tester) async {
+    final String converser = 'John Doe';
+    await tester.pumpWidget(MaterialApp(home: ChatPage(converser)));
+    await tester.pumpAndSettle();
+
+    // Enter Text
+    await tester.enterText(find.byType(TextFormField), 'Hello, John!');
+
+    // Tap the send button
+    await tester.tap(find.byType(ElevatedButton));
+
+    // Wait for animations to complete
+    await tester.pumpAndSettle();
+
+    // Verify that the message is sent
+    expect(find.text('sent: Hello, John!'), findsOneWidget);
+  });
+}

--- a/test/pages_test/devicelistscreen_test.dart
+++ b/test/pages_test/devicelistscreen_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_nearby_connections_example/pages/DevicesListScreen.dart';
+import 'package:flutter_nearby_connections_example/pages/ChatPage.dart';
+import 'package:flutter_nearby_connections_example/classes/Global.dart';
+
+void main() {
+  testWidgets('DevicesListScreen UI Test', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: DevicesListScreen(deviceType: DeviceType.browser)));
+    await tester.pumpAndSettle();
+
+    // Verify that the UI is as expected
+    expect(find.text('Available Devices'), findsOneWidget);
+    expect(find.byType(TextFormField), findsOneWidget);
+    expect(find.byType(ListView), findsOneWidget);
+  });
+
+  testWidgets('DevicesListScreen Interaction Test', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: DevicesListScreen(deviceType: DeviceType.browser)));
+    await tester.pumpAndSettle();
+
+    // Simulate tapping on the first device in the list
+    await tester.tap(find.byType(GestureDetector).first);
+
+    // Wait for animations to complete
+    await tester.pumpAndSettle();
+
+    // Verify that we have navigated to ChatPage
+    expect(find.byType(ChatPage), findsOneWidget);
+  });
+}

--- a/test/pages_test/profile_test.dart
+++ b/test/pages_test/profile_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_nearby_connections_example/pages/Profile.dart';
+import 'package:flutter_nearby_connections_example/pages/DeviceListScreen.dart';
+import 'package:nanoid/nanoid.dart';
+import '../classes/Global.dart';
+
+void main() {
+  testWidgets('Profile UI Test', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: Profile()));
+
+    // Verify that the app has the expected text.
+    expect(find.text("Your Username will be your name+\$custom_length_id"), findsOneWidget);
+    expect(find.byType(TextFormField), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
+  });
+
+  testWidgets('Profile Interaction Test', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: Profile()));
+
+    // Enter a name into the TextFormField.
+    await tester.enterText(find.byType(TextFormField), 'JohnDoe');
+
+    // Tap on the save button.
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    // Verify that the Global.myName is updated.
+    expect(Global.myName, 'JohnDoe');
+
+    // Verify that the navigation to DeviceListScreen occurs.
+    expect(find.byType(DevicesListScreen), findsOneWidget);
+  });
+}


### PR DESCRIPTION
PR for issue https://github.com/AOSSIE-Org/OpenPeerChat-flutter/issues/13
Created an initialize method as it can make the process of writing tests simpler.
With the addition of this method, on calling Global.initialize() before each test case, we can ensure a clean slate.
This method can also allow us to change the initialization process without modifying the entire class. This can be especially useful when the initialization logic evolves over time