### PR TITLE
fixed auth error, updated UI auth failed and AOSSIE text left side

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,11 +70,6 @@ Future<void> requestPermissions() async {
   }
 }
 
-
-
-
-
-
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
@@ -129,46 +124,76 @@ class MyApp extends StatelessWidget {
   }
 }
 
-Future<void> _authenticate(BuildContext context) async {
-  final LocalAuthentication auth = LocalAuthentication();
-  bool authenticated = false;
+Route<dynamic> generateRoute(RouteSettings settings) {
+  if (settings.name == '/') {
+    return MaterialPageRoute(
+      builder: (context) => const AuthenticationPage(),
+    );
+  }
+  // Add other routes as needed
+  return MaterialPageRoute(
+    builder: (context) => const Scaffold(
+      body: Center(child: Text('Route not found')),
+    ),
+  );
+}
+class AuthenticationPage extends StatefulWidget {
+  const AuthenticationPage({Key? key}) : super(key: key);
 
-  try {
-    authenticated = await auth.authenticate(
-      localizedReason: 'Please authenticate to proceed',
-      options: const AuthenticationOptions(
-        stickyAuth: true,
-        sensitiveTransaction: true,
-      ),
-    );
-  } catch (e) {
-    if (kDebugMode) {
-      print(e);
-    }
-  }
-  if (!context.mounted) return;
-  if (authenticated) {
-    Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(builder: (context) => const Profile(onLogin: true)),
-    );
-  } else {
-    Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(builder: (context) => AuthFailedPage(onRetry: () => _authenticate(context))),
-    );
-  }
+  @override
+  State<AuthenticationPage> createState() => _AuthenticationPageState();
 }
 
-Route<dynamic> generateRoute(RouteSettings settings) {
-  return MaterialPageRoute(
-    builder: (context) {
+class _AuthenticationPageState extends State<AuthenticationPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       _authenticate(context);
-      return const Scaffold(
-        body: Center(
-          child: CircularProgressIndicator(),
+    });
+  }
+
+  Future<void> _authenticate(BuildContext context) async {
+    final LocalAuthentication auth = LocalAuthentication();
+    bool authenticated = false;
+
+    try {
+      authenticated = await auth.authenticate(
+        localizedReason: 'Please authenticate to proceed',
+        options: const AuthenticationOptions(
+          stickyAuth: true,
+          sensitiveTransaction: true,
         ),
       );
-    },
-  );
+    } catch (e) {
+      if (kDebugMode) {
+        print(e);
+      }
+    }
+
+    if (!context.mounted) return;
+
+    if (authenticated) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const Profile(onLogin: true)),
+      );
+    } else {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => AuthFailedPage(
+          onRetry: () => _authenticate(context),
+        )),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
 }

--- a/lib/pages/auth_fail.dart
+++ b/lib/pages/auth_fail.dart
@@ -7,25 +7,81 @@ class AuthFailedPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Authentication Failed'),
+        title: Row(
+          children: [
+            Icon(Icons.security_outlined,
+                color: colorScheme.error),
+            const SizedBox(width: 8),
+            Text(
+              'Authentication Failed',
+              style: TextStyle(color: colorScheme.error),
+            ),
+          ],
+        ),
+        backgroundColor: colorScheme.surface,
+        elevation: 0,
       ),
-      body: Center(
+      body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.all(8.0),
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              const Text(
-                'Authentication didn\'t succeed.\nPlease try again.',
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 18),
+              // Error Animation
+              Container(
+                height: 200,
+                width: 200,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: colorScheme.errorContainer.withOpacity(0.1),
+                ),
+                child: Icon(
+                  Icons.error_outline_rounded,
+                  size: 100,
+                  color: colorScheme.error,
+                ),
               ),
-              const SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: onRetry,
-                child: const Text('Try Again'),
+              const SizedBox(height: 32),
+
+              // Error Message
+              Text(
+                'Authentication Failed',
+                style: textTheme.headlineSmall?.copyWith(
+                  color: colorScheme.error,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                "Please try again!",
+                textAlign: TextAlign.center,
+                style: textTheme.bodyLarge?.copyWith(
+                  color: colorScheme.onSurface.withOpacity(0.8),
+                ),
+              ),
+              const SizedBox(height: 48),
+
+              // Retry Button
+              SizedBox(
+                width: double.infinity,
+                height: 56,
+                child: ElevatedButton.icon(
+                  onPressed: onRetry,
+                  icon: const Icon(Icons.refresh_rounded),
+                  label: const Text('Try Again'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: colorScheme.primary,
+                    foregroundColor: colorScheme.onPrimary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                  ),
+                ),
               ),
             ],
           ),
@@ -34,4 +90,3 @@ class AuthFailedPage extends StatelessWidget {
     );
   }
 }
-

--- a/lib/pages/home_screen.dart
+++ b/lib/pages/home_screen.dart
@@ -61,6 +61,7 @@ class _HomeScreenState extends State<HomeScreen> {
         key: Global.scaffoldKey,
         appBar: AppBar(
           title: const Text("AOSSIE"),
+            centerTitle: false,
           actions: [
             IconButton(
               icon: const Icon(Icons.person),


### PR DESCRIPTION
This PR fixes the authentication error that we need to authenticate 2 time to access the app

files changes : 

1. main.dart (authentication code update)
2. auth_fail.dart (UI improvement)
3. home_screen.dart ( made AOSSIE text align left)


changes :

1. Created a dedicated widget for authentication
4. used initState with addPostFrameCallback

what part of previous code was causing the issue  : 
```
Route<dynamic> generateRoute(RouteSettings settings) {
  return MaterialPageRoute(
    builder: (context) {
      _authenticate(context);  // This was the problem
      return const Scaffold(
        body: Center(
          child: CircularProgressIndicator(),
        ),
      );
    },
  );
}
```

The problem was that the ui is not fully initialized and it is asking auth status so the error takes it to the auth fail page

Solution:  The solution is to wait until ui has properly initialized using addPostFrameCallback()
```
class _AuthenticationPageState extends State<AuthenticationPage> {
  @override
  void initState() {
    super.initState();
    WidgetsBinding.instance.addPostFrameCallback((_) {    // waits for ui to load 
      _authenticate(context);
    });
  }

 ...............
```

App with issue video:

https://github.com/user-attachments/assets/30565e29-0fc4-4621-ac7b-e72402e85ce3

Solution video: 

https://github.com/user-attachments/assets/3215b179-1459-4dd4-891f-a275ca5daacb

