### PR TITLE
fix(profile): improve validation and fix padding error

### DIFF
--- a/solution
+++ b/solution
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'home_screen.dart';
+import 'package:nanoid/nanoid.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../classes/global.dart';
+
+class Profile extends StatefulWidget {
+  final bool onLogin;
+  const Profile({Key? key, required this.onLogin}) : super(key: key);
+
+  @override
+  State<Profile> createState() => _ProfileState();
+}
+
+class _ProfileState extends State<Profile> {
+  final TextEditingController myName = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  bool loading = true;
+  String customLengthId = nanoid(6);
+
+  @override
+  void initState() {
+    super.initState();
+    getDetails();
+  }
+
+  @override
+  void dispose() {
+    myName.dispose();
+    super.dispose();
+  }
+
+  Future<void> getDetails() async {
+    final prefs = await SharedPreferences.getInstance();
+    final name = prefs.getString('p_name') ?? '';
+    final id = prefs.getString('p_id') ?? '';
+
+    setState(() {
+      myName.text = name;
+      if (id.isNotEmpty) customLengthId = id;
+      loading = false;
+    });
+
+    // If profile already exists and we arrived here from login flow, go home
+    if (name.isNotEmpty && id.isNotEmpty && widget.onLogin) {
+      navigateToHomeScreen();
+    }
+  }
+
+  void navigateToHomeScreen() {
+    Global.myName = myName.text;
+    if (!widget.onLogin) {
+      Navigator.pop(context);
+    } else {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const HomeScreen()),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Profile')),
+      body: loading
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  // show what the final username will look like
+                  Text('Your username will be: ${myName.text}$customLengthId'),
+                  const SizedBox(height: 16),
+                  Form(
+                    key: _formKey,
+                    child: TextFormField(
+                      controller: myName,
+                      decoration: const InputDecoration(
+                        icon: Icon(Icons.person),
+                        hintText: 'What do people call you?',
+                        labelText: 'Name *',
+                        border: OutlineInputBorder(),
+                      ),
+                      validator: (value) {
+                        final v = value?.trim() ?? '';
+                        if (v.isEmpty) return 'Please enter a name';
+                        if (v.contains('@')) return 'Do not use the @ character';
+                        if (v.length <= 3) return 'Name should be greater than 3 characters';
+                        return null;
+                      },
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () async {
+                      if (!(_formKey.currentState?.validate() ?? false)) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Please fix the errors')),
+                        );
+                        return;
+                      }
+
+                      final prefs = await SharedPreferences.getInstance();
+                      await prefs.setString('p_name', myName.text.trim());
+                      await prefs.setString('p_id', customLengthId);
+
+                      navigateToHomeScreen();
+                    },
+                    child: const Text('Save'),
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+}


### PR DESCRIPTION
### What
- Fixed duplicate padding in Profile screen
- Added proper validator for username (no '@', min 3 characters)
- Disposed TextEditingController to prevent memory leaks
- Improved loading state handling
- Removed duplicate imports at end of file

### Why
- Duplicate padding caused compilation error
- Validator was not working correctly
- Without dispose(), memory leaks could occur
- Cleaner code and better UX

### How
- Tested on emulator (Android)
- Entered invalid name → error shown
- Entered valid name → saved to SharedPreferences and navigated to HomeScreen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Profile screen to set your display name and view a persistent user ID.
  - Live preview shows how your name appears with the ID.
  - Name validation: must be at least 4 characters, cannot contain “@”, and cannot be empty; clear error messages guide corrections.
  - Saves your name and ID on the device for future sessions.
  - After saving, returns to the previous screen or continues to Home when coming from login.
  - Shows a loading indicator while your saved info is retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->